### PR TITLE
feat: Add CI and template for Conventional Commits

### DIFF
--- a/.github/commit-template.txt
+++ b/.github/commit-template.txt
@@ -1,0 +1,9 @@
+# Conventional Commit Format:
+<type>(<optional scope>): <short imperative mood description>
+
+<optional body>
+
+<optional footer>
+
+# Available types:
+# feat,fix,docs,style,refactor,perf,test,chore

--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -1,0 +1,32 @@
+name: "Conventional Commits"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Message
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert

--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 This is a template repository for Rust projects.
 
 This template contains:
-* github actions setup for linting (`cargo clippy`), consistent formatting (`rustfmt`), security advisories (`cargo deny`), and tests.
+* github actions setup for
+    * linting (`cargo clippy`)
+    * consistent formatting (`rustfmt`)
+    * conventional commits
+    * security advisories (`cargo deny`)
+    * tests
 * A minimal crate setup, either for a binary or a lib.
 * Helpful scripts I find myself using consistently for easy local development.
 * A Dockerfile, for binary applications.
+* A commit message template for conventional commits.
 
 That's pretty much it.

--- a/script/setup-local-dev.sh
+++ b/script/setup-local-dev.sh
@@ -12,3 +12,8 @@ cargo install \
     cargo-watch \
     cargo-udeps \
     cargo-deny --locked
+
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+git config commit.template "$REPO_ROOT/.github/commit-template.txt"


### PR DESCRIPTION
This adds a commit template for conventional commits. In addition, the setup-local-dev.sh script now sets the commit template, and there is a CI job to ensure commits and PR messages follow convention.